### PR TITLE
Assign GPU id to the FaissNN search

### DIFF
--- a/bin/load_and_evaluate_patchcore.py
+++ b/bin/load_and_evaluate_patchcore.py
@@ -210,7 +210,7 @@ def patch_core_loader(patch_core_paths, faiss_on_gpu, faiss_num_workers):
                 [x for x in os.listdir(patch_core_path) if ".faiss" in x]
             )
             if n_patchcores == 1:
-                nn_method = patchcore.common.FaissNN(faiss_on_gpu, faiss_num_workers)
+                nn_method = patchcore.common.FaissNN(faiss_on_gpu, faiss_num_workers, device)
                 patchcore_instance = patchcore.patchcore.PatchCore(device)
                 patchcore_instance.load_from_path(
                     load_path=patch_core_path, device=device, nn_method=nn_method
@@ -219,7 +219,7 @@ def patch_core_loader(patch_core_paths, faiss_on_gpu, faiss_num_workers):
             else:
                 for i in range(n_patchcores):
                     nn_method = patchcore.common.FaissNN(
-                        faiss_on_gpu, faiss_num_workers
+                        faiss_on_gpu, faiss_num_workers, device
                     )
                     patchcore_instance = patchcore.patchcore.PatchCore(device)
                     patchcore_instance.load_from_path(

--- a/bin/run_patchcore.py
+++ b/bin/run_patchcore.py
@@ -294,7 +294,7 @@ def patch_core(
             backbone = patchcore.backbones.load(backbone_name)
             backbone.name, backbone.seed = backbone_name, backbone_seed
 
-            nn_method = patchcore.common.FaissNN(faiss_on_gpu, faiss_num_workers)
+            nn_method = patchcore.common.FaissNN(faiss_on_gpu, faiss_num_workers, device)
 
             patchcore_instance = patchcore.patchcore.PatchCore(device)
             patchcore_instance.load(

--- a/src/patchcore/common.py
+++ b/src/patchcore/common.py
@@ -18,6 +18,7 @@ class FaissNN(object):
         Args:
             on_gpu: If set true, nearest neighbour searches are done on GPU.
             num_workers: Number of workers to use with FAISS for similarity search.
+            device: a gpu id or gpu device for FAISS NN search.
         """
         faiss.omp_set_num_threads(num_workers)
         self.on_gpu = on_gpu


### PR DESCRIPTION
_Issue:_ #61

*Description of changes:*
I added the code fraction to assign a GPU id to the GpuIndexFlatL2 by:

In `src/patchcore/common.py`:
```
class FaissNN(object):
    def __init__(self, on_gpu: bool = False, num_workers: int = 4, device: Union[int,torch.device]=0) -> None:
       ...
       if isinstance(device, torch.device):
                  device = int(torch.cuda.current_device())
              self.device = device
       ...

    def _create_index(self, dimension):
        if self.on_gpu:
            gpu_config = faiss.GpuIndexFlatConfig()
            gpu_config.device = self.device
            return faiss.GpuIndexFlatL2(
                faiss.StandardGpuResources(), dimension, gpu_config
            )
        return faiss.IndexFlatL2(dimension)
```

At line 297 in `run_patchcore.py`:
```
...
def get_patchcore(input_shape, sampler, device):
        nn_method = patchcore.common.FaissNN(faiss_on_gpu, faiss_num_workers, device)
...
```

At line 213 and 222 In `load_and_evaluate.py`:
```
def patch_core_loader(patch_core_paths, faiss_on_gpu, faiss_num_workers):
    ...
            if n_patchcores == 1:
                nn_method = patchcore.common.FaissNN(faiss_on_gpu, faiss_num_workers, device)
                patchcore_instance = patchcore.patchcore.PatchCore(device)
                patchcore_instance.load_from_path(
                    load_path=patch_core_path, device=device, nn_method=nn_method
                )
                loaded_patchcores.append(patchcore_instance)
            else:
                for i in range(n_patchcores):
                    nn_method = patchcore.common.FaissNN(
                        faiss_on_gpu, faiss_num_workers, device
                    )
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
