### PR TITLE
Fix missing transform_std and transform_mean attributes in MVTecDataset

### DIFF
--- a/src/patchcore/datasets/mvtec.py
+++ b/src/patchcore/datasets/mvtec.py
@@ -88,6 +88,9 @@ class MVTecDataset(torch.utils.data.Dataset):
 
         self.imagesize = (3, imagesize, imagesize)
 
+        self.transform_std = IMAGENET_STD  
+        self.transform_mean = IMAGENET_MEAN
+
     def __getitem__(self, idx):
         classname, anomaly, image_path, mask_path = self.data_to_iterate[idx]
         image = PIL.Image.open(image_path).convert("RGB")


### PR DESCRIPTION
*Issue #, if available: #35, #80, #15

*Description of changes:*
- Adds `self.transform_std = IMAGENET_STD` to MVTecDataset.__init__
- Adds `self.transform_mean = IMAGENET_MEAN` to MVTecDataset.__init__  
- Uses existing ImageNet constants already defined in the file

*Testing*
- Verified attributes are properly set in dataset initialisation
- Tested backward compatibility - no existing functionality broken
- Confirmed segmentation image saving now works without errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
